### PR TITLE
Multi draggable items feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 dist
 yarn.lock

--- a/examples/components/Canvas/index.tsx
+++ b/examples/components/Canvas/index.tsx
@@ -1,6 +1,7 @@
 import { Wrapper } from "./style";
 import { Data } from "../../types";
 import Container from "../Container";
+import React from "react";
 
 type Props = {
   data: Data;

--- a/examples/components/Canvas/index.tsx
+++ b/examples/components/Canvas/index.tsx
@@ -1,7 +1,7 @@
+import * as React from "react";
 import { Wrapper } from "./style";
 import { Data } from "../../types";
 import Container from "../Container";
-import React from "react";
 
 type Props = {
   data: Data;

--- a/examples/components/Canvas/style.ts
+++ b/examples/components/Canvas/style.ts
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 export const Wrapper = styled.div`
   width: 960px;
-  min-height: 400px;
   padding: 20px;
   border: 1px solid #efefef;
 `;

--- a/examples/components/Container/index.tsx
+++ b/examples/components/Container/index.tsx
@@ -1,9 +1,9 @@
+import * as React from "react";
 import { CSSProperties } from "react";
 import DragItem from "../DragItem";
 import { Wrapper } from "./style";
 import { Data } from "../../types";
 import { Droppable } from "../../../src";
-import React from "react";
 
 type Props = {
   id?: string;
@@ -13,7 +13,7 @@ type Props = {
 };
 
 const Container: React.FC<Props> = (props) => {
-  const { id, data, style, draggableId } = props;
+  const { data, style, draggableId } = props;
   return (
     <Droppable id={"outermost-droppable"} draggableId={draggableId}>
       {(droppableProps) => {

--- a/examples/components/Container/index.tsx
+++ b/examples/components/Container/index.tsx
@@ -3,6 +3,7 @@ import DragItem from "../DragItem";
 import { Wrapper } from "./style";
 import { Data } from "../../types";
 import { Droppable } from "../../../src";
+import React from "react";
 
 type Props = {
   id?: string;
@@ -13,26 +14,28 @@ type Props = {
 
 const Container: React.FC<Props> = (props) => {
   const { id, data, style, draggableId } = props;
-
   return (
-    <Droppable id={id || "outermost-droppable"} draggableId={draggableId}>
-      {(droppableProps) => (
-        <Wrapper
-          {...droppableProps}
-          style={style}
-          noContent={(data || []).length === 0}
-        >
-          {(data || []).map((item, index) => {
-            return (
-              <DragItem
-                data={item}
-                index={index}
-                droppableId={id || "outermost-droppable"}
-              />
-            );
-          })}
-        </Wrapper>
-      )}
+    <Droppable id={"outermost-droppable"} draggableId={draggableId}>
+      {(droppableProps) => {
+        return (
+            <Wrapper
+                {...droppableProps}
+                style={style}
+                noContent={(data || []).length === 0}
+            >
+              {(data || []).map((item, index) => {
+                return (
+                    <DragItem
+                        key={index}
+                        data={item}
+                        index={index}
+                        droppableId={"outermost-droppable"}
+                    />
+                );
+              })}
+            </Wrapper>
+        )
+      }}
     </Droppable>
   );
 };

--- a/examples/components/Container/style.ts
+++ b/examples/components/Container/style.ts
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 
 export const Wrapper = styled.div<{ noContent: boolean; isDragOver: boolean }>`
   width: 100%;
-  min-height: 100%;
+  height: 100%;
   display: flex;
   flex-wrap: wrap;
 
@@ -10,7 +10,7 @@ export const Wrapper = styled.div<{ noContent: boolean; isDragOver: boolean }>`
     noContent &&
     css`
       background-color: #eff0f1;
-    `}
+    `}  
 
   ${({ isDragOver }) =>
     isDragOver &&

--- a/examples/components/DragItem/index.tsx
+++ b/examples/components/DragItem/index.tsx
@@ -2,6 +2,7 @@ import { Item, Wrapper } from "./style";
 import Container from "../Container";
 import { Data } from "../../types";
 import { Draggable } from "../../../src";
+import React from "react";
 
 type Props = {
   data: Data[number];

--- a/examples/components/DragItem/index.tsx
+++ b/examples/components/DragItem/index.tsx
@@ -1,8 +1,9 @@
+import * as React from "react";
 import { Item, Wrapper } from "./style";
 import Container from "../Container";
 import { Data } from "../../types";
 import { Draggable } from "../../../src";
-import React from "react";
+
 
 type Props = {
   data: Data[number];

--- a/examples/components/DragItem/style.ts
+++ b/examples/components/DragItem/style.ts
@@ -3,8 +3,12 @@ import styled, { css } from "styled-components";
 export const Wrapper = styled.div<{ isContainer: boolean }>`
   border: 1px solid #efefef;
   background-color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   min-height: 50px;
   min-width: 200px;
+  border-radius: 10px;
   width: fit-content;
   height: fit-content;
   margin: 10px;

--- a/examples/components/Palette/index.tsx
+++ b/examples/components/Palette/index.tsx
@@ -1,37 +1,43 @@
-import { Draggable } from "../../../src";
-
-import mockItems from "../../mock";
 import { Data } from "../../types";
-import { findData } from "../../utils";
-import { Wrapper, PaletteItem } from "./style";
+import { Wrapper } from "./style";
+import { Droppable } from "../../../src";
+import React from "react";
+import DragItem from "../DragItem";
 
 type Props = {
+  categoryTitle: string;
+  droppableId: string;
   data: Data;
 };
 
 const Palette: React.FC<Props> = (props) => {
-  const { data } = props;
+  const { data, droppableId, categoryTitle } = props;
 
   return (
-    <Wrapper>
-      {mockItems
-        .filter((i) => !findData({ data, id: i.id }))
-        .map(({ id, label }, index) => {
-          return (
-            <Draggable
-              id={id}
-              key={id}
-              index={index}
-              sortable={false}
-              belongsTo="palette"
-            >
-              {(draggableProps) => (
-                <PaletteItem {...draggableProps}>{label}</PaletteItem>
-              )}
-            </Draggable>
-          );
-        })}
-    </Wrapper>
+    <Droppable id={droppableId} >
+      {(droppableProps) => {
+        return (
+            <Wrapper {...droppableProps}>
+              <>
+                <h2>{categoryTitle}</h2>
+                {data
+                    .map((item, index) => {
+                      const { id, label } = item;
+                      return (
+                          <DragItem
+                              key={id+label}
+                              data={item}
+                              index={index}
+                              droppableId={droppableId}
+                          />
+                      );
+                    })}
+              </>
+
+            </Wrapper>
+        )
+      }}
+    </Droppable>
   );
 };
 

--- a/examples/components/Palette/index.tsx
+++ b/examples/components/Palette/index.tsx
@@ -1,23 +1,37 @@
+import * as React from "react";
 import { Data } from "../../types";
 import { Wrapper } from "./style";
 import { Droppable } from "../../../src";
-import React from "react";
 import DragItem from "../DragItem";
+import { useEffect, useState } from "react";
 
 type Props = {
   categoryTitle: string;
   droppableId: string;
   data: Data;
+  draggingId: string;
 };
 
 const Palette: React.FC<Props> = (props) => {
-  const { data, droppableId, categoryTitle } = props;
+  const { data, droppableId, categoryTitle, draggingId } = props;
+  const [itemEntering, setItemEntering] = useState<boolean>();
+
+  // drag completed: reset entering style
+  useEffect(() => {
+    if (!draggingId && itemEntering) {
+      setItemEntering(false);
+    }
+  }, [draggingId])
 
   return (
-    <Droppable id={droppableId} >
+    <Droppable
+        id={droppableId}
+        onDraggedItemEnters={() => setItemEntering(true)}
+        onDraggedItemLeaves={() => setItemEntering(false)}
+    >
       {(droppableProps) => {
         return (
-            <Wrapper {...droppableProps}>
+            <Wrapper {...droppableProps} onDragEnd={() => console.log('drag endddd')} isItemEntering={itemEntering}>
               <>
                 <h2>{categoryTitle}</h2>
                 {data

--- a/examples/components/Palette/index.tsx
+++ b/examples/components/Palette/index.tsx
@@ -27,11 +27,10 @@ const Palette: React.FC<Props> = (props) => {
     <Droppable
         id={droppableId}
         onDraggedItemEnters={() => setItemEntering(true)}
-        onDraggedItemLeaves={() => setItemEntering(false)}
     >
       {(droppableProps) => {
         return (
-            <Wrapper {...droppableProps} onDragEnd={() => console.log('drag endddd')} isItemEntering={itemEntering}>
+            <Wrapper {...droppableProps} isItemEntering={itemEntering}>
               <>
                 <h2>{categoryTitle}</h2>
                 {data

--- a/examples/components/Palette/index.tsx
+++ b/examples/components/Palette/index.tsx
@@ -27,6 +27,7 @@ const Palette: React.FC<Props> = (props) => {
     <Droppable
         id={droppableId}
         onDraggedItemEnters={() => setItemEntering(true)}
+        onDraggedItemLeaves={() => setItemEntering(false)}
     >
       {(droppableProps) => {
         return (

--- a/examples/components/Palette/style.ts
+++ b/examples/components/Palette/style.ts
@@ -1,27 +1,12 @@
 import styled from "styled-components";
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ isItemEntering: boolean }>`
   display: flex;
   flex-direction: column;
   width: 100%;
   background-color: #efefef;
   padding: 20px;
   border: 1px solid white;
-`;
-
-export const PaletteItem = styled.div`
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #efefef;
-  padding: 8px;
-  border-radius: 4px;
-  margin-bottom: 12px;
-  background-color: #fff;
-
-  &:hover {
-    border-color: #3370ff;
-    background-color: #F0F4FF;
-  }
+  
+  background-color: ${({ isItemEntering = false }) => isItemEntering ? 'rgb(212 211 221 / 91%)': '#efefef'};
 `;

--- a/examples/components/Palette/style.ts
+++ b/examples/components/Palette/style.ts
@@ -3,8 +3,10 @@ import styled from "styled-components";
 export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
+  background-color: #efefef;
   padding: 20px;
-  border: 1px solid #efefef;
+  border: 1px solid white;
 `;
 
 export const PaletteItem = styled.div`

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import { useState } from "react";
+import * as ReactDOM from "react-dom";
 import styled from "styled-components";
 
 import { Data } from "./types";
@@ -59,7 +60,6 @@ const App: React.FC = () => {
       }}
     >
       {({ selectedDraggingIds = {}, originDroppable }) => {
-          console.log(categoriesData)
         return (
           <Wrapper>
               {

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -43,10 +43,11 @@ const App: React.FC = () => {
     <DragDropProvider
       rootId="app"
       onDragEnd={({ selectedDraggedIds, from, to }) => {
-        let originData: Data = [];
+        let originData: Data = categoriesData[from.droppableId];
+        const dataToDrag = originData.filter((item) => selectedDraggedIds.includes(item.id));
+
+        // if we drag from one group to another
         if (from.droppableId !== to.droppableId) {
-            originData = categoriesData[from.droppableId];
-            const dataToDrag = originData.filter((item) => selectedDraggedIds.includes(item.id));
             setCategoriesData((catData) => ({
                 ...catData,
                 [from.droppableId]: originData.filter(item => !selectedDraggedIds.includes(item.id)),
@@ -54,6 +55,18 @@ const App: React.FC = () => {
                     ...categoriesData[to.droppableId].slice(0, to.index),
                     ...dataToDrag,
                     ...categoriesData[to.droppableId].slice(to.index),
+                ]
+            }));
+        } else {
+            // reordering in same group
+            // remove items that are moving
+            const items = categoriesData[to.droppableId].filter((data) => !selectedDraggedIds.includes(data.id));
+            setCategoriesData((catData) => ({
+                ...catData,
+                [to.droppableId]: [
+                    ...items.slice(0, to.index),
+                    ...dataToDrag,
+                    ...items.slice(to.index)
                 ]
             }));
         }

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -55,11 +55,11 @@ const App: React.FC = () => {
                     ...dataToDrag,
                     ...categoriesData[to.droppableId].slice(to.index),
                 ]
-            }))
+            }));
         }
       }}
     >
-      {({ selectedDraggingIds = {}, originDroppable }) => {
+      {({ selectedDraggingIds = {}, originDroppable, draggingId }) => {
         return (
           <Wrapper>
               {
@@ -68,6 +68,7 @@ const App: React.FC = () => {
                           key={cat}
                           categoryTitle={categories.find(({ id }) => id === cat)?.title || ''}
                           droppableId={cat}
+                          draggingId={draggingId}
                           data={categoriesData[cat]}
                       />
                       )

--- a/examples/mock.ts
+++ b/examples/mock.ts
@@ -4,5 +4,4 @@ export default [
   { id: "item-3", type: "item", label: "item-3" },
   { id: "item-4", type: "item", label: "item-4" },
   { id: "item-5", type: "item", label: "item-5" },
-  { id: "container", type: "container", label: "container" },
 ];

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss": "^8.3.11",
     "autoprefixer": "^10.4.0",
     "less": "^4.1.2",
-    "eslint": "^8.2.0",
+    "eslint": "^8.14.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "2.5.1",

--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -39,7 +39,6 @@ const DragDropProvider: FC<{
   }) => void;
 }> = (props) => {
   const { rootId, ghostId, children, onDragEnd } = props;
-
   const isReactAbove16 = +React.version.split(".")[0] > 16;
 
   if (isReactAbove16 && !rootId) {
@@ -150,7 +149,6 @@ const DragDropProvider: FC<{
       const droppableId = edgeDraggableIdRef.current
         ? draggableRefs.current[edgeDraggableIdRef.current]?.dataset?.belongsTo
         : droppableIdRef.current;
-
       if (!droppableId || !draggingIdRef.current) return;
 
       const edgeIndex = calcEdgeIndex({

--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -119,12 +119,33 @@ const DragDropProvider: FC<{
 
   const onSelectDraggable = (e:  React.MouseEvent<Element, MouseEvent>, id: string, draggable: HTMLElement | null | undefined) => {
     setSelectedDraggingIds((dict = {}) => {
-      if (draggable && draggable?.dataset?.belongsTo && !dict[draggable.dataset.belongsTo]?.includes(id)) {
+      if (draggable && draggable?.dataset?.belongsTo) {
+        const hasItemBeenAlreadyAdded = dict[draggable.dataset.belongsTo]?.includes(id);
+        const currentDataGroup = dict[draggable.dataset.belongsTo] || [];
+        let updatedGroupData = currentDataGroup
+
+        if (e.type === "click") {
+          // if we press on cmd key for multiple selection
+          if (e.metaKey) {
+            if (!hasItemBeenAlreadyAdded) {
+              updatedGroupData = [...currentDataGroup, id];
+            } else {
+              // remove
+              updatedGroupData = currentDataGroup.filter((item) => item !== id);
+            }
+          } else {
+            // single selection => reset with that id
+            updatedGroupData = [id];
+          }
+        } else if (e.type === "dragstart") {
+          //dragging => will drag already selected ids + the clicked one
+          if (!hasItemBeenAlreadyAdded) {
+            updatedGroupData = [...currentDataGroup, id];
+          }
+        }
         return ({
           ...dict,
-          [draggable.dataset.belongsTo]: e.metaKey && dict[draggable.dataset.belongsTo]
-              ? [...dict[draggable.dataset.belongsTo], id]
-              : [id]
+          [draggable.dataset.belongsTo]: updatedGroupData,
         })
       }
       return dict;

--- a/src/components/Draggable/index.tsx
+++ b/src/components/Draggable/index.tsx
@@ -22,7 +22,6 @@ import {
 } from "../../contexts";
 
 import "./style.less";
-import useDeepCompareEffect from "use-deep-compare-effect";
 
 const getRect = (ref: HTMLElement) => ref.getBoundingClientRect();
 

--- a/src/components/Draggable/index.tsx
+++ b/src/components/Draggable/index.tsx
@@ -10,7 +10,7 @@ import React, {
   ReactNode,
   DragEvent,
   MouseEvent,
-  CSSProperties,
+  CSSProperties, useState,
 } from "react";
 
 import { calcEdge } from "../../utils";
@@ -22,10 +22,11 @@ import {
 } from "../../contexts";
 
 import "./style.less";
+import useDeepCompareEffect from "use-deep-compare-effect";
 
 const getRect = (ref: HTMLElement) => ref.getBoundingClientRect();
 
-const Draggble: FC<{
+const Draggable: FC<{
   id: string;
   index: number;
   style?: CSSProperties;
@@ -53,16 +54,27 @@ const Draggble: FC<{
 
   const { draggingId } = useContext(DragDropContext);
   const { edge, edgeDraggableId } = useContext(DraggableContext);
-  const { setEdge, setDraggingId, setDroppableId, setDraggable } =
+  const { setEdge, setDraggingId, setDroppableId, setDraggable, onSelectDraggable, selectedDraggingIds, setOriginDroppable } =
     useContext(ControllerContext);
+
 
   const isDragging = draggingId === id;
 
   const ref = useRef<HTMLDivElement>(null);
+  const [isSelected, setSelected] = useState<boolean>();
+
+  useEffect(() => {
+    if (selectedDraggingIds && ref?.current?.dataset?.belongsTo) {
+      if (selectedDraggingIds[ref?.current?.dataset?.belongsTo]?.includes(id)) {
+        setSelected(true);
+      } else {
+        setSelected(false);
+      }
+    }
+  }, [selectedDraggingIds])
 
   useEffect(() => {
     setDraggable(id, ref.current);
-
     return () => {
       setDraggable(id, null);
     };
@@ -72,8 +84,9 @@ const Draggble: FC<{
     (e: DragEvent) => {
       e.preventDefault();
       e.stopPropagation();
-
       setDraggingId(id);
+      setOriginDroppable(ref?.current?.dataset?.belongsTo);
+      onSelectDraggable(e, id, ref.current)
     },
     [id, setDraggingId]
   );
@@ -81,19 +94,20 @@ const Draggble: FC<{
   const onMouseOut = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
-
       setEdge();
       setDroppableId();
     },
     [setEdge, setDroppableId]
   );
 
+  const onClick = (e: MouseEvent) => {
+    onSelectDraggable(e, id, ref.current)
+  }
+
   const onMouseMove = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
-
       if (!sortable || !draggingId || isDragging) return;
-
       const edge = calcEdge({
         x: e.clientX,
         y: e.clientY,
@@ -101,10 +115,10 @@ const Draggble: FC<{
         disabledEdges,
         draggableRect: getRect(ref.current!)!,
       });
-
       setEdge(edge, edge ? id : undefined);
 
       if (edge) setDroppableId(belongsTo);
+
     },
     [
       id,
@@ -140,12 +154,14 @@ const Draggble: FC<{
             "data-belongs-to": belongsTo,
             "data-draggable-id": id,
             onMouseOut,
+            onClick,
             onMouseMove,
             onDragStart,
+            className: isSelected ? "isSelected": '',
           })
         : null}
     </div>
   );
 };
 
-export default Draggble;
+export default Draggable;

--- a/src/components/Draggable/index.tsx
+++ b/src/components/Draggable/index.tsx
@@ -100,6 +100,7 @@ const Draggable: FC<{
   );
 
   const onClick = (e: MouseEvent) => {
+    setOriginDroppable(ref?.current?.dataset?.belongsTo);
     onSelectDraggable(e, id, ref.current)
   }
 

--- a/src/components/Draggable/style.less
+++ b/src/components/Draggable/style.less
@@ -11,4 +11,7 @@
       pointer-events: none;
     }
   }
+  div.isSelected {
+    background-color: #F0F4FF;
+  }
 }

--- a/src/components/Droppable/index.tsx
+++ b/src/components/Droppable/index.tsx
@@ -75,6 +75,15 @@ const Droppable: FC<{
     [id, droppableId, setDroppableId]
   );
 
+    const onMouseLeave = useCallback(
+        (e: MouseEvent) => {
+            if (draggingId && onDraggedItemLeaves) {
+                onDraggedItemLeaves(draggingId);
+            }
+        },
+        [id, droppableId]
+    );
+
   const onMouseMove = useCallback(
     (e: MouseEvent) => {
       if (!draggingId || isDragOver) return;
@@ -113,6 +122,7 @@ const Droppable: FC<{
             onMouseOut,
             onMouseMove,
             onMouseEnter,
+            onMouseLeave,
           })
         : null}
     </div>

--- a/src/components/Droppable/index.tsx
+++ b/src/components/Droppable/index.tsx
@@ -3,14 +3,14 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React, {
-  useRef,
-  useEffect,
-  useContext,
-  useCallback,
-  FC,
-  ReactNode,
-  MouseEvent,
-  CSSProperties,
+    useRef,
+    useEffect,
+    useContext,
+    useCallback,
+    FC,
+    ReactNode,
+    MouseEvent,
+    CSSProperties, DragEvent,
 } from "react";
 
 import { Direction, DroppableProps } from "../../types";
@@ -25,6 +25,8 @@ const Droppable: FC<{
   direction?: Direction;
   draggableId?: string;
   children: (droppableProps: DroppableProps) => ReactNode;
+  onDraggedItemEnters?: (draggableId: string | undefined) => void;
+  onDraggedItemLeaves?: (draggableId: string | undefined) => void;
 }> = (props) => {
   const {
     id,
@@ -33,6 +35,8 @@ const Droppable: FC<{
     className,
     direction = Direction.Horizontal,
     draggableId,
+    onDraggedItemEnters,
+    onDraggedItemLeaves,
   } = props;
 
   const ref = useRef<HTMLDivElement>(null);
@@ -50,9 +54,23 @@ const Droppable: FC<{
     };
   }, [id, setDroppable]);
 
+
+  const onMouseEnter = useCallback(
+        (e: MouseEvent) => {
+            if (draggingId && onDraggedItemEnters) {
+                onDraggedItemEnters(draggingId);
+            }
+        },
+        [id, droppableId]
+  );
+
   const onMouseOut = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation();
+
+        if (draggingId && onDraggedItemLeaves) {
+            onDraggedItemLeaves(draggingId);
+        }
 
       if (droppableId !== id) return;
 
@@ -98,6 +116,7 @@ const Droppable: FC<{
             "data-draggable-id": draggableId,
             onMouseOut,
             onMouseMove,
+            onMouseEnter,
           })
         : null}
     </div>

--- a/src/components/Droppable/index.tsx
+++ b/src/components/Droppable/index.tsx
@@ -68,10 +68,6 @@ const Droppable: FC<{
     (e: MouseEvent) => {
       e.stopPropagation();
 
-        if (draggingId && onDraggedItemLeaves) {
-            onDraggedItemLeaves(draggingId);
-        }
-
       if (droppableId !== id) return;
 
       setDroppableId();

--- a/src/contexts.tsx
+++ b/src/contexts.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import React, { createContext } from "react";
 
 import { Edge } from "./types";
 
@@ -41,6 +41,13 @@ type ControllerContextValue = {
   ) => void;
   setDraggingId: (draggableId?: string) => void;
   setDroppableId: (droppableId?: string) => void;
+  setOriginDroppable: (originDroppable: string | undefined) => void
+  onSelectDraggable: (
+      e: React.MouseEvent,
+      draggableId: string,
+      draggableElement: HTMLElement | null | undefined
+  ) => void;
+  selectedDraggingIds: Record<string, string[]> | undefined;
 };
 
 export const ControllerContext = createContext<ControllerContextValue>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,5 @@ export type DroppableProps = {
   "data-draggable-id"?: string;
   onMouseOut: (e: MouseEvent) => void;
   onMouseMove: (e: MouseEvent) => void;
+  onMouseEnter: (e: MouseEvent) => void;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,4 +36,5 @@ export type DroppableProps = {
   onMouseOut: (e: MouseEvent) => void;
   onMouseMove: (e: MouseEvent) => void;
   onMouseEnter: (e: MouseEvent) => void;
+  onMouseLeave: (e: MouseEvent) => void;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export type DraggableProps = {
   onMouseOut: (e: MouseEvent) => void;
   onDragStart: (e: DragEvent) => void;
   onMouseMove: (e: MouseEvent) => void;
+  onClick: (e: MouseEvent) => void;
+  className: string;
 };
 
 export type DroppableProps = {

--- a/types/components/DragDropProvider.d.ts
+++ b/types/components/DragDropProvider.d.ts
@@ -5,6 +5,8 @@ declare const DragDropProvider: FC<{
     children: ReactNode | ((params: {
         draggingId?: string;
         droppableId?: string;
+        selectedDraggingIds?: Record<string, string[]>;
+        originDroppable: string | undefined;
     }) => ReactNode);
     onDragEnd: (params: {
         to: {
@@ -16,6 +18,7 @@ declare const DragDropProvider: FC<{
             droppableId: string;
         };
         draggableId: string;
+        selectedDraggedIds: string[];
     }) => void;
 }>;
 export default DragDropProvider;

--- a/types/components/Draggable/index.d.ts
+++ b/types/components/Draggable/index.d.ts
@@ -1,7 +1,7 @@
 import { FC, ReactNode, CSSProperties } from "react";
 import { Edge, DraggableProps } from "../../types";
 import "./style.less";
-declare const Draggble: FC<{
+declare const Draggable: FC<{
     id: string;
     index: number;
     style?: CSSProperties;
@@ -13,4 +13,4 @@ declare const Draggble: FC<{
     disabledEdges?: Edge[];
     children: (draggableProps: DraggableProps) => ReactNode;
 }>;
-export default Draggble;
+export default Draggable;

--- a/types/components/Droppable/index.d.ts
+++ b/types/components/Droppable/index.d.ts
@@ -8,5 +8,7 @@ declare const Droppable: FC<{
     direction?: Direction;
     draggableId?: string;
     children: (droppableProps: DroppableProps) => ReactNode;
+    onDraggedItemEnters?: (draggableId: string | undefined) => void;
+    onDraggedItemLeaves?: (draggableId: string | undefined) => void;
 }>;
 export default Droppable;

--- a/types/contexts.d.ts
+++ b/types/contexts.d.ts
@@ -1,25 +1,28 @@
-/// <reference types="react" />
+import React from "react";
 import { Edge } from "./types";
 declare type DragDropContextValue = {
     draggingId?: string;
     droppableId?: string;
 };
-export declare const DragDropContext: import("react").Context<DragDropContextValue>;
+export declare const DragDropContext: React.Context<DragDropContextValue>;
 declare type DraggableContextValue = {
     edge?: Edge;
     edgeDraggableId?: string;
 };
-export declare const DraggableContext: import("react").Context<DraggableContextValue>;
+export declare const DraggableContext: React.Context<DraggableContextValue>;
 declare type ConfigContextValue = {
     ghostId?: string;
 };
-export declare const ConfigContext: import("react").Context<ConfigContextValue>;
+export declare const ConfigContext: React.Context<ConfigContextValue>;
 declare type ControllerContextValue = {
     setEdge: (edge?: Edge, draggableId?: string | undefined) => void;
     setDraggable: (draggableId: string, draggableElement: HTMLElement | null | undefined) => void;
     setDroppable: (droppableId: string, draggableElement: HTMLElement | null | undefined) => void;
     setDraggingId: (draggableId?: string) => void;
     setDroppableId: (droppableId?: string) => void;
+    setOriginDroppable: (originDroppable: string | undefined) => void;
+    onSelectDraggable: (e: React.MouseEvent, draggableId: string, draggableElement: HTMLElement | null | undefined) => void;
+    selectedDraggingIds: Record<string, string[]> | undefined;
 };
-export declare const ControllerContext: import("react").Context<ControllerContextValue>;
+export declare const ControllerContext: React.Context<ControllerContextValue>;
 export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,8 @@ declare const _default: {
         direction?: import("./types").Direction | undefined;
         draggableId?: string | undefined;
         children: (droppableProps: import("./types").DroppableProps) => import("react").ReactNode;
+        onDraggedItemEnters?: ((draggableId: string | undefined) => void) | undefined;
+        onDraggedItemLeaves?: ((draggableId: string | undefined) => void) | undefined;
     }>;
     DragDropContext: import("react").Context<{
         draggingId?: string | undefined;
@@ -36,6 +38,8 @@ declare const _default: {
         children: import("react").ReactNode | ((params: {
             draggingId?: string | undefined;
             droppableId?: string | undefined;
+            selectedDraggingIds?: Record<string, string[]> | undefined;
+            originDroppable: string | undefined;
         }) => import("react").ReactNode);
         onDragEnd: (params: {
             to: {
@@ -47,6 +51,7 @@ declare const _default: {
                 droppableId: string;
             };
             draggableId: string;
+            selectedDraggedIds: string[];
         }) => void;
     }>;
 };

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -20,6 +20,8 @@ export declare type DraggableProps = {
     onMouseOut: (e: MouseEvent) => void;
     onDragStart: (e: DragEvent) => void;
     onMouseMove: (e: MouseEvent) => void;
+    onClick: (e: MouseEvent) => void;
+    className: string;
 };
 export declare type DroppableProps = {
     ref: RefObject<HTMLDivElement>;
@@ -29,4 +31,6 @@ export declare type DroppableProps = {
     "data-draggable-id"?: string;
     onMouseOut: (e: MouseEvent) => void;
     onMouseMove: (e: MouseEvent) => void;
+    onMouseEnter: (e: MouseEvent) => void;
+    onMouseLeave: (e: MouseEvent) => void;
 };


### PR DESCRIPTION
This PR provides multiple selection of draggable items.
Instead of relying on `draggableId` which on allows  to cope for single selection, I created a new variable `selectedDraggedIds` in the context API to hold all the items selected in different `droppableId`.

I've modified the display of `ghost` components during the drag so that we can visualise all items being dragged.


https://user-images.githubusercontent.com/3605098/165356985-e7be3e03-a76f-4d94-90fd-3fcf80e3d9c4.mov


