### PR TITLE
fix: 当 DragDropProvider 在同一页面使用多次时，ghostRef 共用导致 Ghost 挂载点被销毁

### DIFF
--- a/src/components/DragDropProvider.tsx
+++ b/src/components/DragDropProvider.tsx
@@ -171,13 +171,14 @@ const DragDropProvider: FC<{
     if (!draggingIdRef.current) return;
 
     if (!ghostRectRef.current)
-      ghostRectRef.current = getGhost().getBoundingClientRect();
+      ghostRectRef.current = getGhost(ghostId).getBoundingClientRect();
 
     const { width, height } = ghostRectRef.current;
 
     transformGhost({
       y: e.pageY - height / 2,
       x: e.pageX - width / 2,
+      ghostId
     });
 
     DragScroller.update(e);

--- a/src/utils/ghost.ts
+++ b/src/utils/ghost.ts
@@ -1,19 +1,23 @@
 import { GHOST_WRAPPER_ID } from "../constants";
 
-const ghostRef = {
-  current: null as HTMLElement | null,
-};
+const ghostRef: Record<string, HTMLElement | null> = {};
+
+const getGhostId = (ghostId?: string): string => {
+  return ghostId || GHOST_WRAPPER_ID;
+}
 
 export const getGhost = (ghostId?: string): HTMLElement => {
-  if (!ghostRef.current) {
-    ghostRef.current = document.getElementById(ghostId || GHOST_WRAPPER_ID)!;
+  ghostId = getGhostId(ghostId);
+
+  if (!ghostRef[ghostId]) {
+    ghostRef[ghostId] = document.getElementById(ghostId)!;
   }
 
-  return ghostRef.current;
+  return ghostRef[ghostId]!;
 };
 
 export const createGhost = (ghostId?: string): void => {
-  if (!getGhost()) {
+  if (!getGhost(ghostId)) {
     const div = document.createElement("div");
 
     div.style.zIndex = "100000";
@@ -24,7 +28,7 @@ export const createGhost = (ghostId?: string): void => {
     div.style.transform = "translate3d(-1000px, -1000px, 0)";
     div.style.pointerEvents = "none";
 
-    div.id = ghostId || GHOST_WRAPPER_ID;
+    div.id = getGhostId(ghostId);
 
     document.body.appendChild(div);
   }
@@ -33,9 +37,11 @@ export const createGhost = (ghostId?: string): void => {
 export const removeGhost = (ghostId?: string): void => {
   const ghost = getGhost(ghostId);
 
+  ghostId = getGhostId(ghostId);
+
   if (ghost) {
     ghost.remove();
-    ghostRef.current = null;
+    ghostRef[ghostId] = null;
   }
 };
 


### PR DESCRIPTION
复现场景：当页面中使用了多处 `DragDropProvider` 且销毁其中一处时，由于 `ghostRef` 是模块内的闭包，几个组件间共用，导致其他 `DragDropProvider` 的 Ghost 挂载点也不可用
解决方案：`ghostRef` 改为 map，按 `glostId` 来存储